### PR TITLE
Change deployment task to use deployment.DeployArchive

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.jelastic</groupId>
     <artifactId>jelastic-maven-plugin</artifactId>
-    <version>2.0.4-LINDAR</version>
+    <version>2.1.0-LINDAR</version>
     <packaging>maven-plugin</packaging>
     <name>jelastic-maven-plugin</name>
     <url>https://github.com/jelastic/jelastic-maven-plugin</url>
@@ -18,7 +18,7 @@
         <dependency>
             <groupId>com.jelastic</groupId>
             <artifactId>jelastic-public-j2se</artifactId>
-            <version>6.0-7</version>
+            <version>7.2-1</version>
         </dependency>
 
         <dependency>

--- a/src/main/java/com/jelastic/AbstractJelasticMojo.java
+++ b/src/main/java/com/jelastic/AbstractJelasticMojo.java
@@ -2,6 +2,7 @@ package com.jelastic;
 
 import com.google.gson.reflect.TypeToken;
 import com.jelastic.api.environment.Control;
+import com.jelastic.api.environment.Deployment;
 import com.jelastic.api.environment.response.NodeSSHResponses;
 import com.jelastic.exception.JelasticApiException;
 import com.jelastic.model.GetDomainsResponse;
@@ -273,7 +274,7 @@ public abstract class AbstractJelasticMojo extends AbstractMojo {
 
     public NodeSSHResponses deploy(String fileName, String fileUrl) {
         String url = getApiJelastic();
-        Control control = new Control(null, getPassword(), "https://" + url + "/1.0/" + Control.SERVICE_PATH);
+        Deployment deployment = new Deployment(null, getPassword(), "https://" + url + "/1.0/" + Deployment.SERVICE_PATH);
         Map<Object, Object> params = new HashMap<>();
         params.put("envName", getEnvironment());
         params.put("fileUrl", fileUrl);
@@ -286,22 +287,26 @@ public abstract class AbstractJelasticMojo extends AbstractMojo {
         }
         params.put("nodeGroup", deployNodeGroup);
 
+        Map<String, Object> hooks = new HashMap<>();
         String preDeployHookContent = getPreDeployHookContent();
         if (preDeployHookContent != null) {
-            params.put("preDeployHook", preDeployHookContent);
+            hooks.put("preDeployHook", preDeployHookContent);
         }
 
         String postDeployHookContent = getPostDeployHookContent();
         if (postDeployHookContent != null) {
-            params.put("postDeployHook", postDeployHookContent);
+            hooks.put("postDeployHook", postDeployHookContent);
+        }
+
+        if (!hooks.isEmpty()) {
+            params.put("hooks", hooks);
         }
 
         Integer delay = getDelay();
         if (delay != null) {
             params.put("delay", delay);
-            params.put("isSequential", true);
         }
-        return control.deployApp(params);
+        return deployment.deployArchive(params);
     }
 
     private List<String> getNodeGroups() {

--- a/src/main/java/com/jelastic/DeployMojo.java
+++ b/src/main/java/com/jelastic/DeployMojo.java
@@ -20,23 +20,21 @@ public class DeployMojo extends AbstractJelasticMojo {
         getLog().info("File Upload: Starting");
         UploadResponse uploadResponse = upload();
         if (uploadResponse.getResult() == 0) {
-            if (uploadResponse.getResult() == 0) {
-                getLog().info("File Upload : SUCCESS");
-                getLog().info("File URL : " + uploadResponse.getFile());
-                getLog().info("File size : " + uploadResponse.getSize());
-                getLog().info("------------------------------------------------------------------------");
+            getLog().info("File Upload : SUCCESS");
+            getLog().info("File URL : " + uploadResponse.getFile());
+            getLog().info("File size : " + uploadResponse.getSize());
+            getLog().info("------------------------------------------------------------------------");
 
-                if (isUploadOnly()) {
-                    return;
-                }
-                NodeSSHResponses deploy = deploy(uploadResponse.getName(), uploadResponse.getFile());
-                if (deploy.getResult() == 0) {
-                    getLog().info("Deploy file : SUCCESS");
-                    getLog().info(deploy.getRaw());
-                } else {
-                    getLog().error("Deploy : FAILED");
-                    getLog().error("Error : " + deploy.getError());
-                }
+            if (isUploadOnly()) {
+                return;
+            }
+            NodeSSHResponses deploy = deploy(uploadResponse.getName(), uploadResponse.getFile());
+            if (deploy.getResult() == 0) {
+                getLog().info("Deploy file : SUCCESS");
+                getLog().info(deploy.getRaw());
+            } else {
+                getLog().error("Deploy : FAILED");
+                getLog().error("Error : " + deploy.getError());
             }
         } else {
             getLog().error("File upload : FAILED");


### PR DESCRIPTION
This PR upgrades the Jelastic library to the latest version and changes the deployment to use `deployment.DeployArchive` instead of `control.DeployApp` which seems to have broke in the latest version of Jelastic.